### PR TITLE
Change the default Timezone handling to UTC

### DIFF
--- a/indico_feeds.features.field.inc
+++ b/indico_feeds.features.field.inc
@@ -299,7 +299,7 @@ function indico_feeds_field_default_fields() {
                 'repeat' => 0,
                 'timezone_db' => 'UTC',
                 'todate' => 'required',
-                'tz_handling' => 'user',
+                'tz_handling' => 'utc',
             ),
             'translatable' => '0',
             'type' => 'datetime',


### PR DESCRIPTION
In the Drupal Community Documentation it is
mentioned: Time zone handling -  UTC: When
entering data into the field, the data entered is
assumed to be in UTC time zone. When the data is
saved to the database, it is converted to UTC
(e.g. no conversion necessary). When retrieved
from the database, the data is converted to the
Site's time zone for anonymous users or the User's
time zone for logged in users when
User-configurable time zones is enabled.
