### PR TITLE
Fix error when uninstalling the module with Feeds module disabled

### DIFF
--- a/indico_feeds.install
+++ b/indico_feeds.install
@@ -93,6 +93,11 @@ function indico_feeds_update_7200() {
 
 function indico_feeds_uninstall() {
     drupal_load('module', 'indico_feeds');
+    //Explicitly load feeds module to use feeds_importer_load_all API call,
+    // only in case it was disabled
+    if(!module_exists("feeds")){
+        drupal_load('module', 'feeds');
+    }
 
     // Delete all indico importers
     foreach(feeds_importer_load_all(true) as $importer) {


### PR DESCRIPTION
Hello Indico team,

We've detected a problem with the module. If the feeds module gets disabled and then the user tries to uninstall the indico-feeds module, there is a error when trying to use "feeds_importer_load_all" function during the indico_feeds_uninstall() call

This is easily resolved with the commit provided, and was already deployed on the CERN Drupal Dev infrastructure, will be deployed into production later on .

Thanks,
Eduardo Alvarez from Drupal Admins CERN